### PR TITLE
Debian Perl Team patchset

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,10 @@ my $libmd = catdir $cwd, 'libmd';
 my $arch = $Config{archname};
 my $is_win32 = ($arch =~ /MSWin32/i && $Config{cc} eq 'cl');
 my $is_387 = ($arch =~ /^i\d+-linux/i);
+my $is_s390 = ($arch =~ /^s390x?-/i);
+my $is_m68k = ($arch =~ /^m68k-/i);
+my $is_ppc = ($arch =~ /^powerpc(64)?-/i);
+my $is_parisc = ($arch =~ /^hppa-/i);
 my $is_sol = ($arch =~ /sun4-solaris|sparc/i);
 my $is_dar = ($arch =~ /darwin/i);
 my $is_cyg = ($arch =~ /cygwin/i || ($arch =~ /MSWin32/i && !$is_win32));
@@ -81,7 +85,7 @@ my $vals = {RETSIGTYPE => {define => 'void', undef => 'int'},
 if ($is_win32 or $is_387 or $is_cyg) {
     $defs{IBMPC} = 1;
 }
-elsif ($is_sol) {
+elsif ($is_sol or $is_s390 or $is_m68k or $is_ppc or $is_parisc) {
     $defs{WORDS_BIGENDIAN} = 1;
     $defs{FLOAT_WORDS_BIGENDIAN} = 1;
     $defs{UNK} = 1;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -356,7 +356,7 @@ typedef struct
 #ifdef __STDC__
 #define ANSIPROT
 /* #include "protos.h" */
-int mtherr();
+int mtherr(char *, int);
 #else
 int mtherr();
 #endif

--- a/libmd/Makefile.PL
+++ b/libmd/Makefile.PL
@@ -31,7 +31,7 @@ unless ($is_387 or $is_sol) {
 }
 
 opendir(DIR, '.') or die "Cannot opendir '.': $!\n";
-my @objs = map {s/\.c$/.o/; $_} grep { /\.c$/ } readdir DIR;
+my @objs = map {s/\.c$/.o/; $_} grep { /\.c$/ } sort readdir DIR;
 closedir DIR;
 my %objs = map {$_ => 1} @objs;
 foreach (qw(setprec.o sqrt.o)) {

--- a/libmd/cpmul_wrap.c
+++ b/libmd/cpmul_wrap.c
@@ -13,6 +13,7 @@
  */
 
 /*							cpmul	*/
+#include "mconf.h"
 
 #ifdef ANSIPROT
 extern void * malloc (long);
@@ -21,12 +22,6 @@ extern void free (void *);
 void * malloc();
 void free ();
 #endif
-
-typedef struct
-	{
-	double r;
-	double i;
-	}cmplx;
 
 int 
 cpmul_wrap( ar, ai, da, br, bi, db, cr, ci, dc )

--- a/libmd/polmisc.c
+++ b/libmd/polmisc.c
@@ -277,7 +277,11 @@ polcos( x, y, nn )
   double a, sc;
   double *w, *c;
   int i;
+#ifdef ANSIPROT
+  double md_sin(double), md_cos(double);
+#else
   double md_sin(), md_cos();
+#endif
   if (nn > N)
     {
       mtherr ("polatn", OVERFLOW);


### PR DESCRIPTION
Hi Shlomi,

While working on the libmath-cephes-perl package within the Debian Perl Team, I accumulated a couple of patches which I believe might be of interest upstream.  You will find a couple of changes that:
  * make the compilation of C bindings reproducible;
  * add support for s390x, m68k, pa-risc and powerpc 32-bit and 64-bit big endian variants;
  * fix build failures with standard C 2023, which were raised in [Debian bug #1097228](https://bugs.debian.org/1097228).

In hope this helps,
Have a nice day,  :)
Étienne.