### PR TITLE
fix `test_static` etc targets to be compatible with EUMM

### DIFF
--- a/libmd/Makefile.PL
+++ b/libmd/Makefile.PL
@@ -100,11 +100,11 @@ static ::    libmd$(LIB_EXT)
 
 config ::
 
-test :
+test ::
 
-test_static :
+test_static ::
 
-test_dynamic :
+test_dynamic ::
 
 END
    return $top_targets;


### PR DESCRIPTION
This is to avoid breakage as shown in https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/467 - EUMM creates `test_*` targets with double-colon, and needs to always create them (with that). With this change, it will still work on older EUMMs.

If this finds favour with you, please could you merge and release it quite soon?